### PR TITLE
API for transforming source code to testcode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { Message, MessageException, log, unexpected } from './message';
 import { Options, getOptions, setOptions } from './options';
 import { sourceAsJavaScript } from './parser';
 import { resolveNames } from './scopes';
-import { vcgenProgram } from './vcgen';
+import { vcgenProgram, transformProgram } from './vcgen';
 import VerificationCondition from './verification';
 import { TEST_PREAMBLE } from './codegen';
 
@@ -46,4 +46,15 @@ export async function verify (src: string, opts: Partial<Options> = {}): Promise
 
 export function testPreamble (): string {
   return TEST_PREAMBLE;
+}
+
+export function transformSourceCode (src: string, opts: Partial<Options> = {}): Message | string {
+  setOptions(opts);
+  try {
+    const prog = sourceAsJavaScript(src);
+    resolveNames(prog);
+    return transformProgram(prog);
+  } catch (e) {
+    return e instanceof MessageException ? e.msg : unexpected(e);
+  }
 }

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -16,10 +16,14 @@ export function vcs (): Array<VerificationCondition> {
   return savedVCs;
 }
 
+export function codeToString (fn: () => any) {
+  const code = fn.toString();
+  return code.substring(14, code.length - 2);
+}
+
 export function code (fn: () => any, each: boolean = false) {
   const setUp = () => {
-    const code = fn.toString();
-    const t = verificationConditions(code.substring(14, code.length - 2));
+    const t = verificationConditions(codeToString(fn));
     if (!(t instanceof Array)) {
       log(t);
       if (t.status === 'error' && t.type === 'unexpected') console.log(t.error);

--- a/tests/transform.ts
+++ b/tests/transform.ts
@@ -1,0 +1,63 @@
+import 'mocha';
+import { expect } from 'chai';
+import { transformSourceCode } from '../src';
+import { sourceAsJavaScript } from '../src/parser';
+import { stringifyTestCode } from '../src/codegen';
+import { codeToString } from './helpers';
+
+declare function ensures (x: boolean | ((y: any) => boolean)): void;
+declare function requires (x: boolean): void;
+declare function assert (x: boolean): void;
+
+function expectTransformation (originalCode: () => any, expectedTransformedSource: string) {
+  const originalSource = codeToString(originalCode);
+  const expectedSource = stringifyTestCode(sourceAsJavaScript(expectedTransformedSource).body);
+  const transformedSource = transformSourceCode(originalSource);
+  expect(transformedSource).to.be.eql(expectedSource);
+}
+
+describe('source transformation', () => {
+
+  it('retains assertions', () => {
+    expectTransformation(() => {
+      const x = 23;
+      const y = 42;
+      assert(x < y);
+    }, `
+    let x = 23;
+    let y = 42;
+    assert(x < y);`);
+  });
+
+  it('changes preconditions to assertions', () => {
+    expectTransformation(() => {
+      function f (x) {
+        requires(Number.isInteger(x));
+        return x;
+      }
+    }, `
+    function f (x) {
+      return x;
+    }
+    f = spec(f, 10371, (function (x) {
+        assert(Number.isInteger(x));
+        return [x];
+    }), (x, _tmp_24438) => _tmp_24438);`);
+  });
+
+  it('changes postconditions to assertions', () => {
+    expectTransformation(() => {
+      function f (x) {
+        ensures(y => y > 3);
+        return x;
+      }
+    }, `
+    function f (x) {
+      return x;
+    }
+    f = spec(f, 10371, x => [x], (function (x, _tmp_24438) {
+        assert(_tmp_24438 > 3);
+        return _tmp_24438;
+    }));`);
+  });
+});


### PR DESCRIPTION
This source code transformation is already implemented for testing verification conditions. However, it should also be possible to transform a complete annotated test program into a program that checks verifier annotations dynamically.

The following example illustrated how an annotated preconditions with `requires` should just be tested at the beginning of the function:

```js
function(x) {
  requires(x > 0);
  return ...
}
```

```js
function(x) {
  if (!(x > 0)) { throw new Error('assertion violation'); }
  return ...
}
```